### PR TITLE
Migrate to webpack@4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,9 @@ language: node_js
 node_js:
   - '8'
   - '6'
-  - '4'
 
 env:
-  - WEBPACK_VERSION=2
-  - WEBPACK_VERSION=3
+  - WEBPACK_VERSION=4.0.1
 
 install:
   - npm install

--- a/package.json
+++ b/package.json
@@ -35,30 +35,31 @@
     "externals"
   ],
   "dependencies": {
-    "babel-runtime": "^6.23.0",
-    "html-webpack-include-assets-plugin": "0.0.7",
-    "read-pkg-up": "^2.0.0",
+    "babel-runtime": "^6.26.0",
+    "html-webpack-include-assets-plugin": "1.0.3",
+    "read-pkg-up": "^3.0.0",
     "resolve-pkg": "^1.0.0"
   },
   "peerDependencies": {
-    "module-to-cdn": "^3.0.1",
-    "webpack": "2 || 3"
+    "module-to-cdn": "^3.1.1",
+    "webpack": "2 || 3 || 4"
   },
   "devDependencies": {
     "all-contributors-cli": "^4.3.0",
-    "ava": "^0.22.0",
-    "babel-cli": "^6.24.1",
-    "babel-core": "^6.24.1",
+    "ava": "^0.25.0",
+    "babel-cli": "^6.26.0",
+    "babel-core": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.23.0",
-    "babel-preset-env": "^1.3.3",
+    "babel-preset-env": "^1.6.1",
     "codecov": "^2.2.0",
-    "html-webpack-plugin": "^2.28.0",
-    "module-to-cdn": "^3.0.4",
+    "html-webpack-plugin": "^3.0.4",
+    "module-to-cdn": "^3.1.1",
     "mz": "^2.6.0",
-    "nyc": "^11.0.3",
+    "nyc": "^11.4.1",
     "rimraf": "^2.6.1",
-    "webpack": "^3.8.1",
-    "webpack-manifest-plugin": "^1.1.0",
+    "webpack": "4.0.1",
+    "webpack-cli": "2.0.10",
+    "webpack-manifest-plugin": "2.0.0-rc.2",
     "xo": "^0.18.2"
   },
   "babel": {
@@ -67,7 +68,7 @@
         "env",
         {
           "targets": {
-            "node": 4
+            "node": 6
           }
         }
       ]


### PR DESCRIPTION
Hey,

I started some work on the webpack migration. I'm stuck at the core logic part since webpack has changed how chunks are handled. I've been reading up on it but haven't been able to completely grok it yet. I added some comments in the code for you to answer.
 
I also updated travis file and the dependencies accordingly.