### PR TITLE
replace NODE_ENV with mode

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -37,10 +37,22 @@
       "profile": "http://blog.fedeoo.cn/",
       "contributions": [
         {
-            "type": "code",
-            "url": "https://github.com/mastilver/dynamic-cdn-webpack-plugin/pull/21"
+          "type": "code",
+          "url": "https://github.com/mastilver/dynamic-cdn-webpack-plugin/pull/21"
         }
       ]
+    },
+    {
+      "login": "aulisius",
+      "name": "​Faizaan",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/6629172?v=4",
+      "profile": "https://github.com/aulisius",
+      "contributions": [
+        "question",
+        "code",
+        "doc"
+      ]
     }
-  ]
+  ],
+  "repoType": "github"
 }

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ import { BrowserRouter } from 'react-router-dom';
 // ... do react stuff
 ```
 
-`NODE_ENV=production webpack` will generate:
+`webpack --mode=production` will generate:
 
 ```js
 /* simplified webpack build */
@@ -117,7 +117,7 @@ import { BrowserRouter } from 'react-router-dom';
 // ... do react stuff
 ```
 
-`NODE_ENV=production webpack` will generate:
+`webpack --mode=production` will generate:
 
 ```js
 /* simplified webpack build */
@@ -158,7 +158,7 @@ Usefull when working offline, will fallback to webpack normal behaviour
 #### options.env
 
 Type: `string`<br>
-Default: `process.env.NODE_ENV || 'development'`<br>
+Default: `mode` used by webpack<br>
 Values: `development`, `production`
 
 Determine if it should load the development or the production version of modules
@@ -203,8 +203,9 @@ The resolver should return (or resolve as a Promise) either `null` or an `object
 Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds/all-contributors#emoji-key)):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-| [<img src="https://avatars3.githubusercontent.com/u/4112409?v=4" width="100px;"/><br /><sub>Thomas Sileghem</sub>](https://github.com/mastilver)<br />[💻](https://github.com/mastilver/dynamic-cdn-webpack-plugin/commits?author=mastilver "Code") [📖](https://github.com/mastilver/dynamic-cdn-webpack-plugin/commits?author=mastilver "Documentation") [⚠️](https://github.com/mastilver/dynamic-cdn-webpack-plugin/commits?author=mastilver "Tests") | [<img src="https://avatars0.githubusercontent.com/u/92839?v=4" width="100px;"/><br /><sub>MICHAEL JACKSON</sub>](https://twitter.com/mjackson)<br />[💡](https://github.com/unpkg/unpkg-demos "Examples") | [<img src="https://avatars2.githubusercontent.com/u/5313455?v=4" width="100px;"/><br /><sub>fedeoo</sub>](http://blog.fedeoo.cn/)<br />[💻](https://github.com/mastilver/dynamic-cdn-webpack-plugin/pull/21 "Code") |
-| :---: | :---: | :---: |
+<!-- prettier-ignore -->
+| [<img src="https://avatars3.githubusercontent.com/u/4112409?v=4" width="100px;"/><br /><sub><b>Thomas Sileghem</b></sub>](https://github.com/mastilver)<br />[💻](https://github.com/mastilver/dynamic-cdn-webpack-plugin/commits?author=mastilver "Code") [📖](https://github.com/mastilver/dynamic-cdn-webpack-plugin/commits?author=mastilver "Documentation") [⚠️](https://github.com/mastilver/dynamic-cdn-webpack-plugin/commits?author=mastilver "Tests") | [<img src="https://avatars0.githubusercontent.com/u/92839?v=4" width="100px;"/><br /><sub><b>MICHAEL JACKSON</b></sub>](https://twitter.com/mjackson)<br />[💡](https://github.com/unpkg/unpkg-demos "Examples") | [<img src="https://avatars2.githubusercontent.com/u/5313455?v=4" width="100px;"/><br /><sub><b>fedeoo</b></sub>](http://blog.fedeoo.cn/)<br />[💻](https://github.com/mastilver/dynamic-cdn-webpack-plugin/pull/21 "Code") | [<img src="https://avatars2.githubusercontent.com/u/6629172?v=4" width="100px;"/><br /><sub><b>​Faizaan</b></sub>](https://github.com/aulisius)<br />[💬](#question-aulisius "Answering Questions") [💻](https://github.com/mastilver/dynamic-cdn-webpack-plugin/commits?author=aulisius "Code") [📖](https://github.com/mastilver/dynamic-cdn-webpack-plugin/commits?author=aulisius "Documentation") |
+| :---: | :---: | :---: | :---: |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/kentcdodds/all-contributors) specification. Contributions of any kind welcome!

--- a/readme.md
+++ b/readme.md
@@ -148,17 +148,29 @@ import { BrowserRouter } from 'react-router-dom';
 
 ### DynamicCdnWebpackPlugin(options)
 
+`webpack.config.js`<br>
+```js
+const DynamicCdnWebpackPlugin = require('dynamic-cdn-webpack-plugin');
+
+module.exports = {
+    mode: 'production',
+    plugins: [
+        new DynamicCdnWebpackPlugin(options)
+    ]
+}
+```
+
 #### options.disable
 
 Type: `boolean`<br>
 Default: `false`
 
-Usefull when working offline, will fallback to webpack normal behaviour
+Useful when working offline, will fallback to webpack normal behaviour
 
 #### options.env
 
 Type: `string`<br>
-Default: `mode` used by webpack<br>
+Default: `mode`<br>
 Values: `development`, `production`
 
 Determine if it should load the development or the production version of modules

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,17 @@ try {
 
 const moduleRegex = /^((?:@[a-z0-9][\w-.]+\/)?[a-z0-9][\w-.]*)/;
 
+const getEnvironment = mode => {
+    switch (mode) {
+        case 'none':
+        case 'development':
+            return 'development';
+
+        default:
+            return 'production';
+    }
+};
+
 export default class DynamicCdnWebpackPlugin {
     constructor({disable = false, env, exclude, only, verbose, resolver} = {}) {
         if (exclude && only) {
@@ -34,7 +45,7 @@ export default class DynamicCdnWebpackPlugin {
 
     apply(compiler) {
         if (!this.disable) {
-            this.execute(compiler, {env: this.env || compiler.options.mode || 'production'});
+            this.execute(compiler, {env: this.env || getEnvironment(compiler.options.mode)});
         }
 
         const isUsingHtmlWebpackPlugin = HtmlWebpackPlugin != null && compiler.options.plugins.some(x => x instanceof HtmlWebpackPlugin);

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ export default class DynamicCdnWebpackPlugin {
         }
 
         this.disable = disable;
-        this.env = env || process.env.NODE_ENV || 'development';
+        this.env = env;
         this.exclude = exclude || [];
         this.only = only || null;
         this.verbose = verbose === true;
@@ -34,7 +34,7 @@ export default class DynamicCdnWebpackPlugin {
 
     apply(compiler) {
         if (!this.disable) {
-            this.execute(compiler, {env: this.env});
+            this.execute(compiler, {env: this.env || compiler.options.mode || 'production'});
         }
 
         const isUsingHtmlWebpackPlugin = HtmlWebpackPlugin != null && compiler.options.plugins.some(x => x instanceof HtmlWebpackPlugin);

--- a/test/core.js
+++ b/test/core.js
@@ -80,7 +80,7 @@ test('using production version', async t => {
     t.false(doesIncludeReact);
 });
 
-test.serial('with mode=production', async t => {
+test('with mode=production', async t => {
     await cleanDir(path.resolve(__dirname, './fixtures/output/node-env-prod'));
 
     const stats = await runWebpack({

--- a/test/core.js
+++ b/test/core.js
@@ -9,8 +9,6 @@ import DynamicCdnWebpackPlugin from '../src';
 import runWebpack from './helpers/run-webpack';
 import cleanDir from './helpers/clean-dir';
 
-process.env.NODE_ENV = 'development';
-
 test('basic', async t => {
     await cleanDir(path.resolve(__dirname, './fixtures/output/basic'));
 
@@ -82,12 +80,12 @@ test('using production version', async t => {
     t.false(doesIncludeReact);
 });
 
-test.serial('with NODE_ENV=production', async t => {
-    process.env.NODE_ENV = 'production';
-
+test.serial('with mode=production', async t => {
     await cleanDir(path.resolve(__dirname, './fixtures/output/node-env-prod'));
 
     const stats = await runWebpack({
+        mode: 'production',
+
         context: path.resolve(__dirname, './fixtures/app'),
 
         output: {
@@ -115,8 +113,6 @@ test.serial('with NODE_ENV=production', async t => {
     // NOTE: not inside t.false to prevent ava to display whole file in console
     const doesIncludeReact = output.includes('THIS IS REACT!');
     t.false(doesIncludeReact);
-
-    delete process.env.NODE_ENV;
 });
 
 test('nested dependencies', async t => {

--- a/test/helpers/run-webpack.js
+++ b/test/helpers/run-webpack.js
@@ -1,7 +1,9 @@
 import webpack from 'webpack';
 
 export default async function (config) {
-    config = Object.assign({}, config, {mode: 'development'});
+    if (!config.mode) {
+        config.mode = 'development';
+    }
 
     return new Promise((resolve, reject) => {
         webpack(config).run((err, stats) => {

--- a/test/html-webpack-plugin.js
+++ b/test/html-webpack-plugin.js
@@ -9,8 +9,6 @@ import DynamicCdnWebpackPlugin from '../src';
 import runWebpack from './helpers/run-webpack';
 import cleanDir from './helpers/clean-dir';
 
-process.env.NODE_ENV = 'development';
-
 test('html-webpack-plugin', async t => {
     await cleanDir(path.resolve(__dirname, './fixtures/output/html-webpack-plugin'));
 

--- a/test/webpack-manifest-plugin.js
+++ b/test/webpack-manifest-plugin.js
@@ -9,8 +9,6 @@ import DynamicCdnWebpackPlugin from '../src';
 import runWebpack from './helpers/run-webpack';
 import cleanDir from './helpers/clean-dir';
 
-process.env.NODE_ENV = 'development';
-
 test('webpack-manifest-plugin', async t => {
     await cleanDir(path.resolve(__dirname, './fixtures/output/webpack-manifest-plugin'));
 


### PR DESCRIPTION
Towards closing #40. 

The breaking change is that I'm defaulting to `production` when an environment is not specified. Since webpack >= 4 does the same when `mode` is omitted, I believe we can do the same thing.

I don't think there is any webpack <= 3 code left to change. README will need to be updated - I think a separate PR will be needed since there'll be other changes to be added in the README once #40 is done.