### PR TITLE
Allow url to be an array

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -136,7 +136,11 @@ export default class DynamicCdnWebpackPlugin {
             for (const [name, cdnConfig] of Object.entries(this.modulesFromCdn)) {
                 compilation.addChunkInGroup(name);
                 const chunk = compilation.addChunk(name);
-                chunk.files.push(cdnConfig.url);
+                if (Array.isArray(cdnConfig.url)) {
+                    chunk.files.push(...cdnConfig.url);
+                } else {
+                    chunk.files.push(...cdnConfig.url);
+                }
             }
 
             cb();

--- a/src/index.js
+++ b/src/index.js
@@ -139,7 +139,7 @@ export default class DynamicCdnWebpackPlugin {
                 if (Array.isArray(cdnConfig.url)) {
                     chunk.files.push(...cdnConfig.url);
                 } else {
-                    chunk.files.push(...cdnConfig.url);
+                    chunk.files.push(cdnConfig.url);
                 }
             }
 


### PR DESCRIPTION
In certain library, it may contain multiple files, e.g., [https://unpkg.com/rc-drawer-menu@0.5.7/dist/](https://unpkg.com/rc-drawer-menu@0.5.7/dist/), one for source code, the other for style file or locale file.