### PR TITLE
Removes babel-plugin-transform-runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "ava": "^0.25.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
-    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.1",
     "codecov": "^3.0.4",
     "html-webpack-plugin": "^3.0.4",
@@ -71,9 +70,6 @@
           }
         }
       ]
-    ],
-    "plugins": [
-      "transform-runtime"
     ]
   },
   "xo": {


### PR DESCRIPTION
This plugin requires the inclusion of babel-runtime as a production dependency, which was removed in a [previous commit](https://github.com/mastilver/dynamic-cdn-webpack-plugin/commit/124e6f9c87adf404e12009e6396d2e145aaf790d). Fixes #57.