### PR TITLE
Drop Node 6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
   - '8'
-  - '6'
 
 env:
   - WEBPACK_VERSION=4

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "mastilver.com"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=8"
   },
   "scripts": {
     "test": "xo && nyc ava",
@@ -67,7 +67,7 @@
         "env",
         {
           "targets": {
-            "node": 6
+            "node": 8
           }
         }
       ]


### PR DESCRIPTION
As Node 6 reaches EOL by end of April 2019, it is wise to drop support for it. This also helps fix #57 